### PR TITLE
  - Preparing fixes for 4.1.3.  These include missing RepeatDB in Rep…

### DIFF
--- a/ProcessRepeats
+++ b/ProcessRepeats
@@ -3723,7 +3723,9 @@ CYCLE9:
               $oldLeft->setRightLinkedHit( $oldRight );
               # RMH: 8/22/22 Fixed a bug reported by David Gordon and others where on rare occasions an
               #      identifier is omitted in the *.out file.
-              $newRight->setLeftLinkedHit( $newHit );
+              if ( $newRight ) {
+                $newRight->setLeftLinkedHit( $newHit );
+              }
               $newHit->checkLinkOrder();
             }
           }
@@ -6096,9 +6098,10 @@ sub generateOutput {
     printf $OUT "   En-Spm           %6d   %10d bp   %5.2f \%\n",
         $uniqCount{"DNA/En-Spm"}, $totlength{"DNA/En-Spm"},
         $totlength{"DNA/En-Spm"} * 100 * $usePerc / $totseqlen;
-    printf $OUT "   MuDR-IS905       %6d   %10d bp   %5.2f \%\n",
-        $uniqCount{"DNA/MuDR"}, $totlength{"DNA/MuDR"},
-        $totlength{"DNA/MuDR"} * 100 * $usePerc / $totseqlen;
+    printf $OUT "   MULE-MuDR        %6d   %10d bp   %5.2f \%\n",
+        $uniqCount{"DNA/MuDR"}+$uniqCount{"DNA/MULE-MuDR"}, 
+        $totlength{"DNA/MuDR"}+$totlength{"DNA/MULE-MuDR"},
+        $totlength{"DNA/MuDR"}+$totlength{"DNA/MULE-MuDR"} * 100 * $usePerc / $totseqlen;
     printf $OUT "   PiggyBac         %6d   %10d bp   %5.2f \%\n",
         $aggregateStats{'DNAPIG'}->{'count'},
         $aggregateStats{'DNAPIG'}->{'length'},

--- a/ReleaseNotes
+++ b/ReleaseNotes
@@ -1,3 +1,10 @@
+4.1.3-p2
+  - A recent change in 4.1.3 to correct blank fragment ID fields can in rare
+    cases causing the error message: 'Can't call method "setLeftLinkedHit"'.
+  - The RepeatAnnotationData.pm file containing necessary information for
+    recognizing equivalent fragments of DNA transposons was missing data.
+  - The MULE-MuDR class was added to the *.tbl file for "-lib" searches.
+
 4.1.3
   - A new utility for generating trackHubs for our new UCSC TE visualization
   - Fix a bug where killing RM while starting up can leave the cached libraries
@@ -7,12 +14,12 @@
   - Fixed legacy RepBase taxonomic labels
   - Added support for GFF v3 output and fixed the utility/rmOutToGFF3.pl
 
-4.1.2p1
-  - Releases 4.1.1-4.1.2 contained a bug with the processing of Alu sequences in 
-    primates. The step where an initial annotation is refined into a particular 
-    Alu subfamily was not performed and the annotations remained labeled with the 
-    initial capture sequence ( AluJb, AluSx, or AluY ). This patch release fixes 
-    this one issue.
+4.1.2-p1
+  - Releases 4.1.1-4.1.2 contained a bug with the processing of Alu sequences 
+    in primates. The step where an initial annotation is refined into a 
+    particular Alu subfamily was not performed and the annotations remained 
+    labeled with the initial capture sequence ( AluJb, AluSx, or AluY ). 
+    This patch release fixes this one issue.
   
 4.1.2
   - Fixed 21 protein family classifications in RepeatProteinLib.

--- a/RepeatMaskerConfig.pm
+++ b/RepeatMaskerConfig.pm
@@ -153,7 +153,7 @@ BEGIN {
 #
 # Current version of the software
 #
-$VERSION = "4.1.3";
+$VERSION = "4.1.3-p1";
 
 #
 # Set this flag to default to debug mode for the entire package


### PR DESCRIPTION
…eatAnnotationData.pm, fixes to the 'Can't call method "setLeftLinkedHit"' bug, and the

addition of the MULE-MuDR class in *.tbl files.