### PR TITLE
forced int type of tax_id in FamDBLeaf.get_lineage() ...

### DIFF
--- a/famdb_classes.py
+++ b/famdb_classes.py
@@ -352,7 +352,7 @@ class FamDBLeaf:
                 if "Parent" in node:
                     if str(node["Parent"][0]) in group_nodes:
                         tax_id = node["Parent"][0]
-                        tree = [tax_id, tree]
+                        tree = [int(tax_id), tree]
                     else:
                         tree = [f"{ROOT_LINK}{tax_id}", tree]
                         tax_id = None


### PR DESCRIPTION
... avoids np.int64 type causing errors in Lineage.__add__(). 

Fixes https://github.com/rmhubley/RepeatMasker/issues/268, https://github.com/rmhubley/RepeatMasker/issues/263
