### PR TITLE
Revert "forced int type of tax_id in FamDBLeaf.get_lineage() ..."

### DIFF
--- a/famdb_classes.py
+++ b/famdb_classes.py
@@ -352,7 +352,7 @@ class FamDBLeaf:
                 if "Parent" in node:
                     if str(node["Parent"][0]) in group_nodes:
                         tax_id = node["Parent"][0]
-                        tree = [int(tax_id), tree]
+                        tree = [tax_id, tree]
                     else:
                         tree = [f"{ROOT_LINK}{tax_id}", tree]
                         tax_id = None


### PR DESCRIPTION
Reverts rmhubley/RepeatMasker#269

The master branch of this repository is RepeatMasker 4.1.6.  This change belongs in the famdb github repository which will be pulled in upon the next RepeatMasker release.